### PR TITLE
Safe import webdriver browsers

### DIFF
--- a/pom/base.py
+++ b/pom/base.py
@@ -34,9 +34,9 @@ __all__ = [
 LOGGER = logging.getLogger(__name__)
 
 browsers = {
-    'firefox': webdriver.Firefox,
-    'phantom': webdriver.PhantomJS,
-    'Chrome': webdriver.Chrome,
+    'firefox': "Firefox",
+    'phantom': "PhantomJS",
+    'Chrome': "Chrome",
 }
 
 
@@ -78,7 +78,7 @@ class App(object):
         """Constructor."""
         self.app_url = url.strip('/')
         LOGGER.info('Start {!r} browser'.format(browser))
-        self.webdriver = browsers[browser](*args, **kwgs)
+        self.webdriver = getattr(webdriver, browsers[browser])(*args, **kwgs)
 
     def open(self, url):
         """Open url.

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     packages=find_packages(),
     url='https://github.com/sergeychipiga/pom',
     install_requires=[
-        'selenium==3.3.0',
-        'waiting==1.3.0',
-        'six==1.11.0',
+        'selenium>=3.3.0',
+        'waiting>=1.3.0',
+        'six>=1.11.0',
     ]
 )


### PR DESCRIPTION
Do not import all drivers during dictionary initialization, instead import only driver that we use.